### PR TITLE
Adding missing permissions for publish job

### DIFF
--- a/.github/workflows/publish-base-docker-image.yml
+++ b/.github/workflows/publish-base-docker-image.yml
@@ -10,6 +10,9 @@ env:
 jobs:
   Build-And-Publish-Docker-Image:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
Adding missing permissions block for `Build-And-Publish-Docker-Image`