### PR TITLE
Renaming default branch to main (SCP-3346)

### DIFF
--- a/.github/workflows/publish-base-docker-image.yml
+++ b/.github/workflows/publish-base-docker-image.yml
@@ -2,7 +2,7 @@ name: Publish rails-baseimage Docker image
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 env:
   GOOGLE_CLOUD_PROJECT: 'broad-singlecellportal-staging'

--- a/.github/workflows/test-base-docker-image.yml
+++ b/.github/workflows/test-base-docker-image.yml
@@ -2,7 +2,7 @@ name: Test rails-baseimage Docker image
 on:
   push:
     branches-ignore:
-      - master
+      - main
   workflow_dispatch:
   pull_request:
 env:

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ you'll want to:
 
 ## Publishing changes ##
  
-To publish your changes, you'll need to increment the version number in `./version.txt` (in accordance with [SemVer](https://semver.org/), please), and get your changes committed, pushed, and merged into the `master` branch. At that point, [this Github workflow](https://github.com/broadinstitute/scp-rails-baseimage/actions/workflows/publish-base-docker-image.yml) will attempt to build and publish your changes to GCR.  It is not recommended (or likely possible) to publish locally.
+To publish your changes, you'll need to increment the version number in `./version.txt` (in accordance with [SemVer](https://semver.org/), please), and get your changes committed, pushed, and merged into the `main` branch. At that point, [this Github workflow](https://github.com/broadinstitute/scp-rails-baseimage/actions/workflows/publish-base-docker-image.yml) will attempt to build and publish your changes to GCR.  It is not recommended (or likely possible) to publish locally.

--- a/ci/check_for_newer_dependencies
+++ b/ci/check_for_newer_dependencies
@@ -27,7 +27,7 @@ function assert_git_tag_is_latest {
 
     if [ "$latest_git_tag" != "$DEPENDENCY_REPO_RELEASE_TAG" ]; then
         local DEPENDENCY_REPO_COMPARE_URL="$DEPENDENCY_REPO_URL/compare/$DEPENDENCY_REPO_RELEASE_TAG...$latest_git_tag"
-        exit_with_error_message "This is not the latest released version of $DEPENDENCY_REPO_URL --use $latest_git_tag instead in \"./requirements.bash\" a.k.a. \"$BASE_GITHUB_URL/blob/master/requirements.bash\". You can see what has changed at $DEPENDENCY_REPO_COMPARE_URL . There are more details in the playbook at https://docs.google.com/document/d/1vJz6hXdjAu8LBAfIS4oMy7yLIUX177gU1H7BxTPPzAU/edit#heading=h.8gg7zdig7ttm ."
+        exit_with_error_message "This is not the latest released version of $DEPENDENCY_REPO_URL --use $latest_git_tag instead in \"./requirements.bash\" a.k.a. \"$BASE_GITHUB_URL/blob/main/requirements.bash\". You can see what has changed at $DEPENDENCY_REPO_COMPARE_URL . There are more details in the playbook at https://docs.google.com/document/d/1vJz6hXdjAu8LBAfIS4oMy7yLIUX177gU1H7BxTPPzAU/edit#heading=h.8gg7zdig7ttm ."
     fi
 
     popd || exit 1


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This renames the `master` branch to `main` and replaces any references with the new name.  This will affect CD jobs to build/test/publish Docker images, and any local copies developer have with the old branch already checked out.  To update your local repository, run the following commands:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```