### PR TITLE
Updating to Passenger 3.1.3, Ruby 3.4.4

### DIFF
--- a/.github/workflows/publish-base-docker-image.yml
+++ b/.github/workflows/publish-base-docker-image.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   Build-And-Publish-Docker-Image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/test-base-docker-image.yml
+++ b/.github/workflows/test-base-docker-image.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   Build-And-Test-Docker-Image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ CMD ["/sbin/my_init"]
 #   Node.js and Meteor support.
 #RUN /pd_build/nodejs.sh
 
-# Update bundler
+# Update rubygems and bundler
+RUN gem update --system
 RUN gem install bundler
 
 # Install imagemagick + dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # See https://github.com/phusion/passenger-docker/blob/master/Changelog.md for
 # a list of version numbers.
 
-FROM singlecellportal/phusion_passenger-ruby34:3.1.2
+FROM singlecellportal/phusion_passenger-ruby34:3.1.3
 #FROM singlecellportal/phusion_passenger-full:1.0.8
 
 # Or, instead of the 'full' variant, use one of these:

--- a/requirements.bash
+++ b/requirements.bash
@@ -2,7 +2,7 @@ BASE_IMAGE="marketplace.gcr.io/google/ubuntu2404:latest" #aggressively keep up w
 
 # pin to versioned releases of phusion images to avoid breakages
 PHUSION_BASE_IMAGE_REPO="phusion/baseimage-docker"
-PHUSION_BASE_IMAGE_VERSION="noble-1.0.2"
+PHUSION_BASE_IMAGE_VERSION="noble-1.0.0"
 
 PHUSION_PASSENGER_IMAGE_REPO="phusion/passenger-docker"
 PHUSION_PASSENGER_IMAGE_VERSION="3.1.3" #if you change this, you'll have to change the "FROM" line in ./Dockerfile also.

--- a/requirements.bash
+++ b/requirements.bash
@@ -2,7 +2,7 @@ BASE_IMAGE="marketplace.gcr.io/google/ubuntu2404:latest" #aggressively keep up w
 
 # pin to versioned releases of phusion images to avoid breakages
 PHUSION_BASE_IMAGE_REPO="phusion/baseimage-docker"
-PHUSION_BASE_IMAGE_VERSION="noble-1.0.0"
+PHUSION_BASE_IMAGE_VERSION="noble-1.0.2"
 
 PHUSION_PASSENGER_IMAGE_REPO="phusion/passenger-docker"
 PHUSION_PASSENGER_IMAGE_VERSION="3.1.3" #if you change this, you'll have to change the "FROM" line in ./Dockerfile also.

--- a/requirements.bash
+++ b/requirements.bash
@@ -5,4 +5,4 @@ PHUSION_BASE_IMAGE_REPO="phusion/baseimage-docker"
 PHUSION_BASE_IMAGE_VERSION="noble-1.0.0"
 
 PHUSION_PASSENGER_IMAGE_REPO="phusion/passenger-docker"
-PHUSION_PASSENGER_IMAGE_VERSION="3.1.2" #if you change this, you'll have to change the "FROM" line in ./Dockerfile also.
+PHUSION_PASSENGER_IMAGE_VERSION="3.1.3" #if you change this, you'll have to change the "FROM" line in ./Dockerfile also.


### PR DESCRIPTION
Applying security patches and updating to the latest Phusion Passenger image versions, and Ruby 3.4.4.  Also, this moved the `gem update --system` and `gem install bundler` calls into `rails-baseimage` , rather than having this execute on all builds of the `single-cell-portal` image.

Additionally, this updates the Action runners to use the newer `ubuntu-24.04` images.